### PR TITLE
Move api url to dotenv configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ npm run lint
 
 ### DOTENV
 
-You will need credentials, that have proper access to [directus](https://directus.io). After that you just have to create a *.env.local* file in the project root and copy the folling lines into it.
+You will need credentials, that have proper access to [directus](https://directus.io). You will find an example configuration file in the project root. Just rename it like so:
 
 ```
-VUE_APP_USERNAME = "yourUsername"
-VUE_APP_PASSWORD = "yourPAssword"
+mv example.env.local .env.local
 ```
+
+After that, you just have to fill in your credentials and a valid api url
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/example.env.local
+++ b/example.env.local
@@ -1,0 +1,4 @@
+# Project config
+VUE_APP_USERNAME = "yourUsername"
+VUE_APP_PASSWORD = "yourPassword"
+VUE_APP_API_URL = "urlToAPI"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "campsitedb",
+  "name": "campsite-db",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/helper/routes.ts
+++ b/src/helper/routes.ts
@@ -1,6 +1,5 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 export enum ROUTE {
-  BASE = "https://directus.dpsg-os.de/api",
   AUTH = "/auth/authenticate",
   COLLECTIONS = "/collections",
   ITEMS = "/items/"
@@ -20,7 +19,7 @@ const createBaseUrl = (collectionName: string) => {
   if (!collectionName) {
     return false;
   }
-  return `${ROUTE.BASE}${ROUTE.ITEMS}${collectionName}?`;
+  return `${process.env.VUE_APP_API_URL}${ROUTE.ITEMS}${collectionName}?`;
 };
 
 /**

--- a/src/services/campsiteService.ts
+++ b/src/services/campsiteService.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { ROUTE, CREDENTIALS } from "@/helper/routes";
 
 const apiClient = axios.create({
-  baseURL: ROUTE.BASE,
+  baseURL: process.env.VUE_APP_API_URL,
   withCredentials: false, // This is the default
   headers: {
     Accept: "application/json",


### PR DESCRIPTION
To prepare this project for different environments it's convenient
to change credentials AND also the backend url quickly.